### PR TITLE
Fixed fontawesome icon stack-overflow to fa-stack-overflow

### DIFF
--- a/host/resourcesnew/cwh/js/printJobs.js
+++ b/host/resourcesnew/cwh/js/printJobs.js
@@ -131,7 +131,7 @@
 				return "fa-diamond";
 			}
 			if (printable.printFileProcessor.friendlyName === 'Zip of Slice Images') {
-				return "stack-overflow";
+				return "fa-stack-overflow";
 			}
 			return "fa-question-circle";
 		}

--- a/host/resourcesnew/cwh/js/printables.js
+++ b/host/resourcesnew/cwh/js/printables.js
@@ -111,7 +111,7 @@
 				return "fa-diamond";
 			}
 			if (printable.printFileProcessor.friendlyName === 'Zip of Slice Images') {
-				return "stack-overflow";
+				return "fa-stack-overflow";
 			}
 			return "fa-question-circle";
 		}


### PR DESCRIPTION
Made a mistake in the comment I gave you, the icon class is `fa-stack-overflow`, not `stack-overflow`. This PR fixes that in the two js files you indicated.