### PR TITLE
Remove dependencies on command-line git

### DIFF
--- a/host/BuildCWH.xml
+++ b/host/BuildCWH.xml
@@ -2,24 +2,12 @@
 <project name="Packaging Generator" default="BuildCWH">
 	<property environment="env"/>
 
-	<target name="git" description="Store git revision in ${repository.version}">
-	    <exec executable="git" outputproperty="git.revision" failifexecutionfails="false" errorproperty="">
-	        <arg value="describe"/>
-	        <arg value="--abbrev=5"/>
-	        <arg value="--always"/>
-	        <arg value="--tags"/>
-	    </exec>
-	    <condition property="repo.version" value="${git.revision}" else="unknown">
-	        <and>
-	            <isset property="git.revision"/>
-	            <length string="${git.revision}" trim="yes" length="0" when="greater"/>
-	        </and>
-	    </condition>
-			<echo>Repo version is: ${repo.version}</echo>
-	</target>
-
-	<target name="BuildCWH" depends="git" description="build server and client">
+	<target name="BuildCWH" description="build server and client">
 		<buildnumber/>
+
+		<condition property="repo.version" value="${repo.version}" else="unknown">
+			<isset property="repo.version" />
+		</condition>
 
 		<condition property="deployedServerZipFile" value="cwh-${repo.version}-${build.number}.zip"
 			else="cwh-0.${build.number}.zip">

--- a/host/build.gradle
+++ b/host/build.gradle
@@ -25,9 +25,27 @@ github {
 import org.ajoberstar.grgit.*
 
 ant.importBuild 'build.xml'
-grgit = Grgit.open(project.file('..'), new Credentials(releaseRepoOwner, releaseRepoToken));
+grgit = Grgit.open(project.file('..'), new Credentials(releaseRepoOwner, releaseRepoToken))
+def commitVersion = "unknown"
 
 // Tasks:
+task repoVersion() << {
+  commitVersion = grgit.describe()
+
+  if (commitVersion == null) {
+    def history = grgit.log(maxCommits: 1)
+    commitVersion = history[0].id.take(5)
+  }
+
+  ant.properties['repo.version'] = commitVersion
+
+  println("Git Commit Description: "+commitVersion)
+}
+
+task dist(dependsOn: ['build', 'BuildCWH', 'repoVersion']) {
+
+}
+
 task setupRelease() << {
 
   if (releaseRepoToken.equals('GITHUB_API_TOKEN')) {
@@ -72,3 +90,5 @@ task setupRelease() << {
 
 // Post-setup
 githubRelease.dependsOn setupRelease
+BuildCWH.mustRunAfter build
+BuildCWH.mustRunAfter repoVersion

--- a/host/build.xml
+++ b/host/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <project name="cwh" basedir="." default="build">
-  <include file="BuildCWH.xml" as="packaging"/>
+  <import file="BuildCWH.xml"/>
 
   <property name="build" location="srcbin"/>
   <property name="testbuild" location="testbin"/>
@@ -105,8 +105,10 @@
     </copy>
   </target>
 
-  <target name="dist" depends="build,packaging.BuildCWH">
+  <!-- Moved to Gradle
+  <target name="dist" depends="build,BuildCWH">
   </target>
+  -->
 
   <target name="run" depends="build,os">
     <java classname="org.area515.resinprinter.server.Main"


### PR DESCRIPTION
All the dist generating logic is now done through grgit in gradle. No environmental dependencies (except for Java itself) remain.

Tested with the Build (with Windows) launcher.