### PR TITLE
Fixes to newstart process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: true
+dist: trusty
 git:
   depth: 3
 language: java
@@ -6,9 +7,16 @@ jdk:
 - oraclejdk8
 os:
 - linux
+addons:
+  apt:
+    packages:
+      - librxtx-java
+install:
+  - sudo apt-get install -y librxtx-java
 script:
   - chmod a+rx host/gradlew
-  - "(cd host ; ./gradlew clean dist)"
+  - "(cd host ; gradle clean dist)"
+  - "(cd host/bin ; sudo bash -x ./newstart.sh)"
 deploy:
   - provider: bintray
     file: ".bintray.yml"
@@ -19,7 +27,7 @@ deploy:
       all_branches: true
   - provider: releases
     skip_cleanup: true
-    prerelease: true
+    prerelease: false
     api_key:
       secure: "lt+86YtJtOUeUTdY2PDtIe0vzBEktq0YNGg7N/1xAp/QedzHThhGqORg3dCjZ4MH43WzD7Jq1hMiwU8VBWfdikY+Y1rsGzOSK5UFJmNKSH6Bxe5RoHC2NE8hcb6pwEQQr6aQsRRpwMSDPGWg3RfbA9lamXpT+WHTACZPIhGXjpL0mWLWPQsJqa6HaiZ4hJ6mhASHtGznANPbPDP6P2HnNbh0nvHAhVS/p58OJrXN0ICj9hALjOxcXZZQjxh0bY5VAhKBwAdfXDkJRpderw14qW1w+yuyr4qs3J0x9k4KV4FLCFEc4aWr5tsfEIC5AB2ztEzqYHXjXMWh1qpMSmwcdYM0ygUw0K4gTUKyvCJT7rWn6DQS6oYGgYiTufDR6alBKK04rPnSueg5BWILqLLUJLw9XFyjyi7M+u1nJF8YReVLE9kYeGzvy7iKRQZE58EyBC5mpo8LPqdqAPbjn20I5wUPOWA6zDUfrCCkNTXTAGKbdKqoKKSt1WYu5mT+ND2/i22XqJrSmvrGt1QYS+/JnAEPvNlEiLxMHJ0L0l8F5yUYqMJ5upul0Nlacds/oIRjNWbjsuFZ/adnTiNxOY+JQCWZfZdSwFMNs75seYS5DXYVbNDrtyTnD2aK9xg5EDPwgtvpYB0c9g1isAKRkfOzuUKZncrcVtDLstgwrDl68dg="
     file_glob: true

--- a/host/BuildCWH.xml
+++ b/host/BuildCWH.xml
@@ -9,17 +9,17 @@
 			<isset property="repo.version" />
 		</condition>
 
-		<condition property="deployedServerZipFile" value="cwh-${repo.version}-${build.number}.zip"
+		<condition property="deployedServerZipFile" value="cwh-${repo.version}.zip"
 			else="cwh-0.${build.number}.zip">
 			<istrue value="${env.CI}"/>
 		</condition>
 
-		<condition property="deployedTestZipFile" value="cwhTestKit-${repo.version}-${build.number}.zip"
+		<condition property="deployedTestZipFile" value="cwhTestKit-${repo.version}.zip"
 			else="cwhTestKit-0.${build.number}.zip">
 			<istrue value="${env.CI}"/>
 		</condition>
 
-		<condition property="deployedClientZipFile" value="cwhClient-${repo.version}-${build.number}.zip"
+		<condition property="deployedClientZipFile" value="cwhClient-${repo.version}.zip"
 			else="cwhClient-0.${build.number}.zip">
 			<istrue value="${env.CI}"/>
 		</condition>

--- a/host/bin/newstart.sh
+++ b/host/bin/newstart.sh
@@ -12,7 +12,7 @@ else
 	fi;
 fi;
 
-if [ "$2" == "TestKit" ]; then 
+if [ "$2" == "TestKit" ]; then
 	downloadPrefix=cwh$2-
 	installDirectory=/opt/cwh$2
 else
@@ -21,11 +21,11 @@ else
 fi;
 
 #Its pretty hard to keep these updated, let me know when they get too old
-if [ "${cpu}" = "armv6l" -o "${cpu}" = "armv7l" ]; then 
+if [ "${cpu}" = "armv6l" -o "${cpu}" = "armv7l" ]; then
 	javaURL="http://download.oracle.com/otn-pub/java/jdk/8u73-b02/jdk-8u73-linux-arm32-vfp-hflt.tar.gz"
-elif [ "${cpu}" = "i686" ]; then 
+elif [ "${cpu}" = "i686" ]; then
 	javaURL="http://download.oracle.com/otn-pub/java/jdk/8u73-b02/jdk-8u73-linux-i586.tar.gz"
-elif [ "${cpu}" = "x86_64" ]; then 
+elif [ "${cpu}" = "x86_64" ]; then
 	javaURL="http://download.oracle.com/otn-pub/java/jdk/8u73-b02/jdk-8u73-linux-x64.tar.gz"
 fi
 
@@ -64,34 +64,37 @@ if [ "$javaMinorVersion" -lt 8 -a "$javaMajorVersion" -le 1 ]; then
 	cd /usr/lib/jvm
 	rm ${downloadJavaFile}
 	wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "${javaURL}"
-	
+
 	firstSnapshot=`ls -1`
 	echo Unzipping and installing Java now
 	tar xzf ${downloadJavaFile}
 	secondSnapshot=`ls -1`
 	javaInstallFile=`echo "$firstSnapshot"$'\n'"$secondSnapshot" | sort | uniq -u`
-	
+
 	if [ -z "${javaInstallFile}" ]; then
 		echo "A new version of Java is available, please update this script with the proper download URLS from: http://www.oracle.com/technetwork/java/javase/downloads/index.html"
 		exit
 	fi
-	
+
 	ln -sf /usr/lib/jvm/${javaInstallFile}/bin/java /usr/bin/java
 	ln -sf /usr/lib/jvm/${javaInstallFile}/bin/javac /usr/bin/javac
-	ln -sf /usr/lib/jvm/${javaInstallFile}/bin/keytool /usr/bin/keytool		
+	ln -sf /usr/lib/jvm/${javaInstallFile}/bin/keytool /usr/bin/keytool
 	rm ${downloadJavaFile}
 fi
 
 #Determine if a new install is available
+echo Checking for new version from Github Repo: ${repo}
 cd ${installDirectory}
 LOCAL_TAG=$(grep repo.version build.number | cut -d = -f 2)
 NETWORK_TAG=$(curl -s https://api.github.com/repos/${repo}/releases/latest | grep 'tag_name' | cut -d\" -f4)
 
+echo Local Tag: ${LOCAL_TAG}
+echo Network Tag: ${NETWORK_TAG}
 
 if [ -f ${downloadPrefix}.*.zip ]; then
 	OFFLINE_FILE=$(ls ${downloadPrefix}.*.zip)
 	echo Performing offline install of ${OFFLINE_FILE}
-	
+
 	mv ${OFFLINE_FILE} ~
 	rm -r ${installDirectory}
 	mkdir -p ${installDirectory}
@@ -102,23 +105,32 @@ if [ -f ${downloadPrefix}.*.zip ]; then
 	rm ${OFFLINE_FILE}
 elif [ "${NETWORK_TAG}" != "${LOCAL_TAG}" -o "$2" == "force" ]; then
 	echo Installing latest version of ${downloadPrefix}: ${NETWORK_TAG}
-	
+
+	DL_URL=$(curl -s https://api.github.com/repos/${repo}/releases/latest | grep 'browser_' | cut -d\" -f4 | grep ${downloadPrefix})
+	DL_FILE=${DL_URL##*/}
+	wget -P /tmp "${DL_URL}"
+  if [ $? -ne 0 ]; then
+		echo "wget of ${DL_FILE} failed. Aborting update."
+		exit 1
+	fi
+
 	rm -r ${installDirectory}
 	mkdir -p ${installDirectory}
 	cd ${installDirectory}
-	wget $(curl -s https://api.github.com/repos/${repo}/releases/latest | grep 'browser_' | cut -d\" -f4 | grep ${downloadPrefix})
-	unzip ${downloadPrefix}*.zip
+	mv "/tmp/${DL_FILE}" .
+
+	unzip ${DL_FILE}
 	chmod 777 *.sh
-	rm ${downloadPrefix}*.zip
+	rm ${DL_FILE}
 else
 	echo No install required
-	
+
 fi
 
 echo Turning off screen saver and power saving
 xset s off         # don't activate screensaver
 xset -dpms         # disable DPMS (Energy Star) features
-xset s noblank     # don't blank the video device 
+xset s noblank     # don't blank the video device
 
 if [ ! -f "/etc/init.d/cwhservice" ]; then
 	echo Installing CWH as a service


### PR DESCRIPTION
Make newstart.sh more resiliant and less destructive on network failures
Run newstart.sh in travis-ci
Only use tag name for release binaries generated by CI

This includes a change to newstart.sh that should make it work with the weird windows githubReleases filenames by only using downloadPrefix to identify the binary on the release page that needs to be downloaded. Then, the actual filename that is unzipped, moved around, deleted, etc... is based on parsing the URL, not based on attempting to re-form the filename with the prefix and other info.

This also makes newstart more resilient to naming differences.